### PR TITLE
Harmonize terminology across documentation

### DIFF
--- a/docs/core-concepts/location-proofs.md
+++ b/docs/core-concepts/location-proofs.md
@@ -1,1 +1,30 @@
-# Location proofs
+# Location Proofs
+
+Location proofs are verification evidence that can be attached to location attestations. While location attestations contain the actual spatial data (coordinates, geometries, etc.), location proofs provide evidence or verification of the authenticity of that spatial data.
+
+## What are Location Proofs?
+
+Location proofs serve as the verification layer for location attestations. They:
+
+- Provide evidence that a claim about a location is valid
+- Can be generated through various verification strategies
+- Are attached to location attestations as part of the Location Protocol
+
+## Types of Location Proofs
+
+The Location Protocol supports many different approaches to verification:
+
+- **Authority-based proofs**: Verification from trusted entities like event organizers
+- **Social proofs**: Verification from other users who can confirm location claims
+- **Hardware-based proofs**: Evidence from devices like Bluetooth beacons, NFC, or RFID
+- **Network-based proofs**: Evidence from network triangulation or signal analysis
+- **Sensor data proofs**: Evidence from environmental readings that match expected values
+
+## Relationship to Location Attestations
+
+Location attestations are the primary data structure in the Location Protocol, while location proofs provide the evidence that makes these attestations trustworthy:
+
+- **Location attestation**: "I was at coordinates 37.7749° N, 122.4194° W at 2:00pm"
+- **Location proof**: Evidence supporting that claim, such as a beacon signal, network data, or third-party verification
+
+The Location Protocol is designed to accommodate various proof strategies through the [Location Proof Extensions](../location-protocol/strategies-recipes.md) framework.

--- a/docs/developer-resources/location-attestations.md
+++ b/docs/developer-resources/location-attestations.md
@@ -1,1 +1,42 @@
-# Location attestations
+# Location Attestations
+
+Location attestations are the core building blocks of the decentralized geospatial web. They are structured, signed records containing location data, metadata, and attachments that form the foundation of the Location Protocol.
+
+## What are Location Attestations?
+
+Location attestations are structured data records that:
+
+- Contain spatial information in standardized formats
+- Are cryptographically signed to establish authorship and integrity
+- Are timestamped to establish when they were created
+- Can include metadata and attachments
+- May be linked to verification evidence (location proofs)
+
+## Structure of a Location Attestation
+
+A Location Attestation includes:
+
+1. **Spatial data**: Coordinates, geometries, or other geospatial information
+2. **Metadata**: Information about the attestation such as timestamp, author, etc.
+3. **Format information**: Details about how the spatial data is encoded
+4. **Optional attachments**: Media or other relevant data
+5. **Optional location proofs**: Evidence verifying the authenticity of the location claim
+
+## Creating Location Attestations
+
+Location attestations are created using the Ethereum Attestation Service (EAS) and follow the schema defined by the Location Protocol. They can be:
+
+- Created by users to document their location
+- Issued by applications to track spatial data
+- Generated automatically by devices or services
+
+For a practical guide on creating location attestations, see the [quickstart guide](../location-protocol/quickstart.md).
+
+## Relationship to Location Proofs
+
+While location attestations contain the actual spatial data, location proofs provide evidence of its authenticity:
+
+- **Location attestation**: The primary record containing spatial data ("I was at this location")
+- **Location proof**: Verification evidence attached to the attestation ("Here's proof that I was there")
+
+Location attestations can exist without location proofs, but location proofs are always attached to attestations.

--- a/docs/location-protocol/introduction.md
+++ b/docs/location-protocol/introduction.md
@@ -10,9 +10,9 @@ Astral's Location Protocol provides a standardized structure for representing sp
 - **Extensible spatial format support**: Handles points, lines, polygons, and complex geometries needed for mapping applications — any spatial data format can be supported
 - **Universal spatial representation**: Works across Earth-centered coordinates, other planetary systems, and virtual worlds using established formats like GeoJSON, decimal coordinates and other location data formats
 - **Rich media attachments**: Connects photos, videos, sensor readings, and documents to spatial data
-- **Extensible verification framework**: Accommodates location proofs created from various location verification systems and techniques
+- **Extensible verification framework**: Accommodates location proofs (verification evidence) that can be attached to location attestations using various verification systems and techniques
 
-The Location Protocol is built on the Ethereum Attestation Service (EAS) — it defines a core schemas to create location data that carries clear attribution, timestamp information, attached data, and optional location evidence.
+The Location Protocol is built on the Ethereum Attestation Service (EAS) — it defines core schemas to create location attestations that carry clear attribution, timestamp information, attached data, and optional location proofs.
 
 
 
@@ -21,10 +21,9 @@ This section of the docs includes:
 - A [quickstart guide](./quickstart.md) to creating location proofs — note this will be updated soon to use the Astral SDK!
 - Specifications of the core [Ethereum Attestation Service (EAS) schema](./eas-schema.md) for the protocol, and UIDs of deployments on
   Base, Celo and Arbitrum mainnets, and Ethereum Sepolia testnet.
-- Information on our Location Extensions Library, which provides an interoperability framework for different location data formats: [Location Extensions](./location-types.md)
-- Details on an extensible framework (in development) for building [location proof "recipes"](./strategies-recipes.md) to support different proof-of-location systems
-  location to be added (WIP)
-- Details on our extensible (notice a pattern here?) framework for attaching different types of [media](./media-extensions.md) to location proofs
+- Information on our Location Format Extensions Library, which provides an interoperability framework for different location data formats: [Location Format Extensions](./location-types.md)
+- Details on our [Location Proof Extensions](./strategies-recipes.md) framework for supporting different proof-of-location systems and verification strategies
+- Details on our [Media Extensions](./media-extensions.md) framework for attaching different types of media to location attestations
 
 ## Contributing
 

--- a/docs/location-protocol/location-types.md
+++ b/docs/location-protocol/location-types.md
@@ -1,12 +1,12 @@
 ---
 id: location-types
-title: Location Extensions Library Overview
-sidebar_label: Location Extensions
+title: Location Format Extensions Library Overview
+sidebar_label: Location Format Extensions
 ---
 
-# Location Extensions Library Overview
+# Location Format Extensions Library Overview
 
-The Location Extensions Library is a core component of Astral's Location Proof Protocol, designed to provide a flexible, standardized way to work with a diversity of geospatial data. This Location Extensions Library contains detailed information defining a range of different location types supported by the protocol. Code for creating, parsing and validating this geospatial data is implemented in the Astral SDK repo.
+The Location Format Extensions Library is a core component of Astral's Location Protocol, designed to provide a flexible, standardized way to work with a diversity of geospatial data. This Location Format Extensions Library contains detailed information defining a range of different location types supported by the protocol. Code for creating, parsing and validating this geospatial data is implemented in the Astral SDK repo.
 
 ## Overview
 
@@ -79,12 +79,12 @@ Note that for v0.1, the only spatial reference system (`srs`) supported is WGS84
 
 ### Additional Considerations
 
-The Location Proof Protocol is intended to be as interoperable with the rest of the geospatial web as possible. One way to think about location proofs is as a wrapper around a geospatial data artifact that includes digital signatures and evidence about its truthfulness or authenticity. 
+The Location Protocol is intended to be as interoperable with the rest of the geospatial web as possible. One way to think about location proofs is as a wrapper around a geospatial data artifact that includes digital signatures and evidence about its truthfulness or authenticity. 
 
 In that sense, location proofs are spatio-temporal assets. We are considering how to integrate / harmonize the Location Proof Protocol with the STAC spec — weigh in [here](https://github.com/DecentralizedGeo/location-proofs/issues/2).
 
 ## Conclusion
 
-The Location Extensions Library provides a robust and adaptable framework for handling a wide range of geospatial data types. By employing a clean, dot-notation naming convention for our Location Format Identifiers, we ensure that our system is both intuitive and forward-compatible. With clear distinctions between vector and raster data, the library is well-positioned to accommodate emerging data types while maintaining simplicity and consistency.
+The Location Format Extensions Library provides a robust and adaptable framework for handling a wide range of geospatial data types. By employing a clean, dot-notation naming convention for our Location Format Identifiers, we ensure that our system is both intuitive and forward-compatible. With clear distinctions between vector and raster data, the library is well-positioned to accommodate emerging data types while maintaining simplicity and consistency.
 
 For contributions, questions, or further discussions, please refer to our contributing guidelines and join our [community channels](https://t.me/+UkTOSXnDcDM5ZTBk).

--- a/docs/location-protocol/media-extensions.md
+++ b/docs/location-protocol/media-extensions.md
@@ -8,7 +8,22 @@ sidebar_label: Media Extensions
 
 The Media Extensions Library is a core component of Astral's Location Protocol, designed to provide a standardized way to handle various media types that can be attached to location attestations. This Media Extensions Library leverages existing MIME types as identifiers, making it compatible with web standards while ensuring flexibility for extending to specialized media formats.
 
-## Overview
+Users have the capability to attach a diverse range of media types to location attestations. This functionality is powered by the use of MIME types, allowing for the inclusion of various data formats such as photos, videos, audio, URLs, LIDAR scans, point clouds, and more.
+
+## Media Structure
+
+Location attestations have two fields related to media:
+
+- **`mediaType`**: An array of strings, each a unique MIME type designator of the media attached, to ease parsing when attestations are read
+- **`mediaData`**: An array of strings containing media data or identifiers, typically a [CID](https://docs.ipfs.tech/concepts/content-addressing/) for larger media
+
+Elements in each array correspond according to index. This allows any set of media data to be attached to a location attestation, enabling use cases such as geotagged photos and videos, dMRV data for impact/regeneration projects, and more.
+
+:::note
+Data included in the media fields should NOT be required for the location proof strategy. For example, if a strategy used photos of the surrounding area (i.e., of known landmarks), this data should be included in the proof recipe.
+:::
+
+## Media Types Overview
 
 Each media format is defined by a MIME type identifier (included in the `mediaType` attribute). In the `media` attribute, a payload can be found that contains the media data or a reference to it. This approach enables:
 

--- a/docs/location-protocol/media-extensions.md
+++ b/docs/location-protocol/media-extensions.md
@@ -1,12 +1,12 @@
 ---
 id: media-extensions
-title: Media Extensions Library Overview
+title: Media Extensions
 sidebar_label: Media Extensions
 ---
 
-# Media Extensions Library Overview
+# Media Extensions
 
-The Media Extensions Library is a core component of Astral's Location Proof Protocol, designed to provide a standardized way to handle various media types that can be attached to location proofs. This Media Extensions Library leverages existing MIME types as identifiers, making it compatible with web standards while ensuring flexibility for extending to specialized media formats.
+The Media Extensions Library is a core component of Astral's Location Protocol, designed to provide a standardized way to handle various media types that can be attached to location attestations. This Media Extensions Library leverages existing MIME types as identifiers, making it compatible with web standards while ensuring flexibility for extending to specialized media formats.
 
 ## Overview
 

--- a/docs/location-protocol/quickstart.md
+++ b/docs/location-protocol/quickstart.md
@@ -1,9 +1,10 @@
 # Quickstart
 
-Building with Astral Location Proofs is easy.
+Building with Astral's Location Protocol is easy.
 
-- Create location proofs using the EAS SDK and the Location Proof Protocol schema
-- Resolve location proofs using the EAS SDK
+- Create location attestations using the EAS SDK and the Location Protocol schema
+- Attach location proofs to attestations for verification
+- Resolve location attestations using the EAS SDK
 
 The EAS SDK is documented [here](https://docs.attest.org/docs/welcome) — below we put together the workflow in javascript — copy and adapt as needed. [Here is a current version of EAS.config.](https://github.com/AstralProtocol/logbook/blob/main/packages/nextjs/EAS.config.ts)
 

--- a/docs/location-protocol/strategies-recipes.md
+++ b/docs/location-protocol/strategies-recipes.md
@@ -1,4 +1,10 @@
-# Strategies + Recipes
+---
+id: strategies-recipes
+title: Location Proof Extensions
+sidebar_label: Location Proof Extensions
+---
+
+# Location Proof Extensions
 
 The generalized location proof protocol is designed as it is to accommodate the wide range of strategies for proving location on the
 decentralized web, while also provided a standard way of representing these proofs.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -45,7 +45,6 @@ const sidebars = {
         'location-protocol/eas-schema',
         'location-protocol/location-types',
         'location-protocol/strategies-recipes',
-        'location-protocol/media-attachments',
         'location-protocol/media-extensions',
       ],
     },


### PR DESCRIPTION
- Rename 'Location Proof Protocol' to 'Location Protocol'
- Update 'Location Extensions Library' to 'Location Format Extensions Library'
- Standardize sidebar labels (Location Format Extensions, Location Proof Extensions, Media Extensions)
- Clarify distinction between location attestations and location proofs
- Add comprehensive documentation for both concepts